### PR TITLE
Google Maps - Client Address

### DIFF
--- a/src/app/models/client_addresses.js
+++ b/src/app/models/client_addresses.js
@@ -1,0 +1,35 @@
+const Sequelize = require('sequelize');
+const database = require('../database');
+
+module.exports = database.sequelize.define(
+    'client_addresses',
+    {
+        id: {
+            type: Sequelize.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        client_id: {
+            type: Sequelize.INTEGER,
+            references: {
+                model: 'clients',
+                key: 'id'
+            }
+        },
+        latitude: {
+            type: Sequelize.STRING
+        },
+        longitude: {
+            type: Sequelize.STRING
+        },
+        address_name: {
+            type: Sequelize.STRING
+        },
+        current: {
+            type: Sequelize.BOOLEAN
+        }
+    },
+    {
+        timestamps: false
+    }
+)

--- a/src/public/js/google-map.js
+++ b/src/public/js/google-map.js
@@ -5,6 +5,9 @@
 // This example requires the Places library. Include the libraries=places
 // parameter when you first load the API. For example:
 // <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&libraries=places">
+var latitude = '';
+var longitude = '';
+var address = '';
 
 function initAutocomplete() {
     var map = new google.maps.Map(document.getElementById('map'), {
@@ -75,6 +78,10 @@ function initAutocomplete() {
                 infowindow.open(map, marker);
             });
 
+            setAddress(marker.title);
+            setLatitude(marker.getPosition().lat());
+            setLongitude(marker.getPosition().lng());
+
             if (place.geometry.viewport) {
                 // Only geocodes have viewport.
                 bounds.union(place.geometry.viewport);
@@ -92,8 +99,23 @@ function initAutocomplete() {
             if (status === 'OK') {
                 if (results[0]) {
                     marker.title = results[0].formatted_address;
+                    setAddress(marker.title);
+                    setLatitude(marker.getPosition().lat());
+                    setLongitude(marker.getPosition().lng());
                 }
             }
         })
+    };
+
+    function setAddress(addr) {
+        address = addr;
+    };
+
+    function setLatitude(lat) {
+        latitude = lat;
+    };
+
+    function setLongitude(long) {
+        longitude = long;
     };
 }

--- a/src/public/js/google-map.js
+++ b/src/public/js/google-map.js
@@ -74,7 +74,6 @@ function initAutocomplete() {
             marker.addListener('dragend', function () {
                 var geocoder = new google.maps.Geocoder;
                 geocodeLatLng(geocoder, marker.getPosition(), marker);
-                infowindow.setContent(marker.title);
                 infowindow.open(map, marker);
             });
 
@@ -99,6 +98,7 @@ function initAutocomplete() {
             if (status === 'OK') {
                 if (results[0]) {
                     marker.title = results[0].formatted_address;
+                    infowindow.setContent(marker.title);
                     setAddress(marker.title);
                     setLatitude(marker.getPosition().lat());
                     setLongitude(marker.getPosition().lng());

--- a/src/public/js/google-map.js
+++ b/src/public/js/google-map.js
@@ -26,6 +26,11 @@ function initAutocomplete() {
     var markers = [];
     // Listen for the event fired when the user selects a prediction and retrieve
     // more details for that place.
+
+    var infowindow = new google.maps.InfoWindow({
+        content: ''
+    });
+
     searchBox.addListener('places_changed', function () {
         var places = searchBox.getPlaces();
 
@@ -45,6 +50,7 @@ function initAutocomplete() {
                 console.log("Returned place contains no geometry");
                 return;
             }
+
             var icon = {
                 url: place.icon,
                 size: new google.maps.Size(71, 71),
@@ -65,6 +71,8 @@ function initAutocomplete() {
             marker.addListener('dragend', function () {
                 var geocoder = new google.maps.Geocoder;
                 geocodeLatLng(geocoder, marker.getPosition(), marker);
+                infowindow.setContent(marker.title);
+                infowindow.open(map, marker);
             });
 
             if (place.geometry.viewport) {
@@ -73,6 +81,7 @@ function initAutocomplete() {
             } else {
                 bounds.extend(place.geometry.location);
             }
+
         });
         map.fitBounds(bounds);
     });

--- a/src/public/js/google-map.js
+++ b/src/public/js/google-map.js
@@ -8,7 +8,7 @@
 
 function initAutocomplete() {
     var map = new google.maps.Map(document.getElementById('map'), {
-        center: { lat: -33.8688, lng: 151.2195 },
+        center: { lat: 4.6788055, lng: -74.0576059 },
         zoom: 13,
         mapTypeId: 'roadmap'
     });
@@ -37,7 +37,6 @@ function initAutocomplete() {
         markers.forEach(function (marker) {
             marker.setMap(null);
         });
-        markers = [];
 
         // For each place, get the icon, name and location.
         var bounds = new google.maps.LatLngBounds();
@@ -55,14 +54,18 @@ function initAutocomplete() {
             };
 
             // Create a marker for each place.
-            markers.push(new google.maps.Marker({
+            var marker = new google.maps.Marker({
                 map: map,
                 icon: icon,
                 title: place.name,
-                position: place.geometry.location
-            }));
+                position: place.geometry.location,
+                draggable: true
+            });
 
-            alert(markers[0].position);
+            marker.addListener('dragend', function () {
+                var geocoder = new google.maps.Geocoder;
+                geocodeLatLng(geocoder, marker.getPosition(), marker);
+            });
 
             if (place.geometry.viewport) {
                 // Only geocodes have viewport.
@@ -73,4 +76,15 @@ function initAutocomplete() {
         });
         map.fitBounds(bounds);
     });
+
+
+    function geocodeLatLng(geocoder, coordinates, marker) {
+        geocoder.geocode({ 'location': coordinates }, function (results, status) {
+            if (status === 'OK') {
+                if (results[0]) {
+                    marker.title = results[0].formatted_address;
+                }
+            }
+        })
+    };
 }

--- a/src/views/clientHome.ejs
+++ b/src/views/clientHome.ejs
@@ -28,6 +28,9 @@
   <link rel="stylesheet" href="css/icomoon.css">
   <link rel="stylesheet" href="css/style.css">
 
+  <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
+  <script src="js/jquery.min.js"></script>
+
 </head>
 
 <body>
@@ -81,11 +84,33 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
-          <button type="button" class="btn btn-primary">Registrar</button>
+          <form>
+            <button id="registerAddress" type="button" class="btn btn-primary">Register</button>
+          </form>
         </div>
       </div>
     </div>
   </div>
+
+  <script>
+    $("#registerAddress").click(function () {
+      swal({
+        title: "Please Confirm Address",
+        text: address,
+        icon: "warning",
+        buttons: ["Return", "Confirm"]
+      })
+        .then((confirmed) => {
+          if (confirmed) {
+            swal({
+              title: "Location Saved!",
+              text: "Now is time to order",
+              icon: "success"
+            })
+          }
+        })
+    });
+  </script>
 
   <footer class="ftco-footer ftco-bg-dark ftco-section">
     <div class="container">

--- a/src/views/clientHome.ejs
+++ b/src/views/clientHome.ejs
@@ -76,7 +76,7 @@
           </button>
         </div>
         <div class="modal-body">
-          <input id="pac-input" class="controls" type="text" placeholder="Search Box">
+          <input id="pac-input" class="controls" type="text" placeholder="Ingrese su ubicación">
           <div id="map"></div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
The GMaps has been implemented and the client has the option to use a searchbox to find a specific address - The client also can move the google map marker and drag it to their desire location - When the client is done with their address a modal screen will appear and it will ask for confirmation showing the final address selected

The longitude, latitude and address are not stored in the database yet but the client_addresses model is already done

There are still minor fixes to be done such as:
- Sometimes there are multiple markers (When the client searches and draggess the marker and researches again)
- There is not validation for only Bogotá locations yet
- 